### PR TITLE
Add option to concat the IP/domain in list's domain

### DIFF
--- a/lib/dnsbl-client/dnsbl-client.rb
+++ b/lib/dnsbl-client/dnsbl-client.rb
@@ -94,11 +94,11 @@ module DNSBL
 				label = normalize(item)
 			end
 
-            if domain.match '%s'
-                lookup = domain % label
-            else
+      if domain.match '%s'
+        lookup = domain % label
+      else
 				lookup = "#{label}.#{domain}"
-            end
+      end
 
 			txid = lookup.sum
 			message = Resolv::DNS::Message.new(txid)

--- a/test/test_dnsbl-client.rb
+++ b/test/test_dnsbl-client.rb
@@ -42,10 +42,10 @@ class TestDnsblClient < Test::Unit::TestCase
 		assert_equal("example.act.edu.au", c.normalize("foo.bar.example.act.edu.au"))
 	end
 
-    should "allow concat in list domain" do
-        c = DNSBL::Client.new
+  should "allow concat in list domain" do
+    c = DNSBL::Client.new
 
-        result = c._encode_query('127.0.0.1', 'ip', 'test.%s.example.org')
-        assert_equal(result, "\b3\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00\x04test\x011\x010\x010\x03127\aexample\x03org\x00\x00\x01\x00\x01")
-    end
+    result = c._encode_query('127.0.0.1', 'ip', 'test.%s.example.org')
+    assert_equal(result, "\b3\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00\x04test\x011\x010\x010\x03127\aexample\x03org\x00\x00\x01\x00\x01")
+  end
 end


### PR DESCRIPTION
Some blacklists require a key before the IP like Project Honeypot. 

Considering that the lookup IP is 127.0.0.1, the host would be:

mykey.1.0.0.127.dnsbl.httpbl.org

It's not possible to do with the current version of the gem since it always concat ip + host.

I made a small commit that fix it.
