### PR TITLE
Remove SPAMCANNIBAL because it was hijacked and no longer active

### DIFF
--- a/data/dnsbl.yaml
+++ b/data/dnsbl.yaml
@@ -153,10 +153,6 @@ NOMOREFUN:
   127.0.0.9: See http://moensted.dk/spam/no-more-funn/?addr=$
   127.0.0.10: Possible open proxy
   127.0.0.11: Please stop testing our servers
-SPAMCANNIBAL:
-  domain: bl.spamcannibal.org
-  type: ip
-  127.0.0.2: Blacklisted
 UCEPROTECT1:
   domain: dnsbl-1.uceprotect.net
   type: ip


### PR DESCRIPTION
See https://mxtoolbox.com/problem/blacklist/spamcannibal:
> IMPORTANT: SpamCannibal is no longer an active list. It should not be used.

And https://www.dnsbl.info/bl-spamcannibal-org.php:
> SpamCannibal Offline, On 5/30/2019 the domain for SpamCannibal.org lapsed for the second time and is now blacklisting the entire internet.